### PR TITLE
Fix badge metadata example

### DIFF
--- a/types/badge/Badge.md
+++ b/types/badge/Badge.md
@@ -13,7 +13,7 @@ A Badge with the metadata and the list of the holders.
 
 ```json
 {
-  "info": {
+  "metadata": {
     "name": "Whale",
     "description": "A really whalethy user",
     "image": {


### PR DESCRIPTION
metadata object key is `"metadata"` rather than `"info"`